### PR TITLE
Contributing a TapisLocalCache subclass

### DIFF
--- a/tapipy/client.py
+++ b/tapipy/client.py
@@ -1,0 +1,95 @@
+import datetime
+import json
+import os
+
+from tapipy.tapis import Tapis
+
+__all__ = ['TapisLocalCache']
+
+DEFAULT_CACHE_FILE = 'client.json'
+
+
+class TapisLocalCache(Tapis):
+    def __init__(self, cache_dir=None, cache=None, **kwargs):
+        setattr(self, 'user_tokens_cache_path',
+                self.path_to_cache(cache_dir, cache))
+        super().__init__(**kwargs)
+
+    @classmethod
+    def path_to_cache(cls, cache_dir=None, cache=None):
+        # Cache directory resolves as:
+        # 1. Provided value 2. TAPIS3_CACHE_DIR 3. ~/.tapis3
+        if cache_dir is None:
+            cache_dir = os.environ.get('TAPIS3_CACHE_DIR',
+                                       os.path.expanduser('~/.tapis3'))
+        if cache is None:
+            cache = DEFAULT_CACHE_FILE
+        return os.path.join(cache_dir, cache)
+
+    @classmethod
+    def restore(cls, cache_dir=None, cache=None, password=None):
+        """Load Tapis from a cached client
+
+        It is possible to provide a password to support the 
+        case where the refresh token is expired.
+        """
+        cache_path = cls.path_to_cache(cache_dir, cache)
+        with open(cache_path, 'r') as cl:
+            data = json.load(cl)
+            t = TapisLocalCache(base_url=data['base_url'],
+                                tenant_id=data['tenant_id'],
+                                access_token=data['access_token'],
+                                refresh_token=data['refresh_token'],
+                                client_id=data['client_id'],
+                                client_key=data['client_key'],
+                                username=data['username'],
+                                password=password,
+                                verify=True)
+            return t
+
+    def refresh_user_tokens(self):
+        """Refresh access and refresh tokens, then save to cache
+        """
+        class DateTimeEncoder(json.JSONEncoder):
+            #Override the default method
+            def default(self, obj):
+                if isinstance(obj, (datetime.date, datetime.datetime)):
+                    return obj.isoformat()
+
+        resp = super().refresh_user_tokens()
+
+        # Not sure we need to do these checks...
+        if isinstance(self.access_token, str):
+            access_token = self.access_token
+            expires_at = None
+        else:
+            access_token = self.access_token.access_token
+            expires_at = self.access_token.expires_at
+        if isinstance(self.access_token, str):
+            refresh_token = self.refresh_token
+        else:
+            refresh_token = self.refresh_token.refresh_token
+
+        data = {
+            'base_url': self.base_url,
+            'tenant_id': self.tenant_id,
+            'username': self.username,
+            'client_id': self.client_id,
+            'client_key': self.client_key,
+            'access_token': access_token,
+            'refresh_token': refresh_token,
+            'expires_at': expires_at
+        }
+
+        # Wrap in a try block in case writing fails. This supports use of
+        # TapisLocalCache inside a read-only environment such as a container
+        try:
+            cache_dir = os.path.dirname(self.user_tokens_cache_path)
+            if not os.path.isdir(cache_dir):
+                os.makedirs(cache_dir, exist_ok=True)
+            with open(self.user_tokens_cache_path, 'w') as cl:
+                json.dump(data, cl, cls=DateTimeEncoder, indent=4)
+        except Exception as exc:
+            warnings.warn('Failed to write to cache file: {0}'.format(exc))
+
+        return resp


### PR DESCRIPTION
# Overview

This Python class subclasses `Tapis`, adding a persistent, configurable cache file to hold the current Tapis client, access token, & refresh token for later usage. The default path for the cache is `~/.tapis3/client.json` but this can be overridden either by setting `TAPIS3_CACHE_DIR` or by providing `cache_dir` and `cache` keyword arguments to the `restore` class method. 

# Usage

```python
from tapipy.client import TapisLocalCache
t = TapisLocalCache.restore()
t.get_tokens()
t.refresh_tokens()
```

