### PR TITLE
Added missing cloudpickle dependency for tapipy.actors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requests = "*"
 atomicwrites = "^1.4.0"
 cryptography = "^3.3.2"
 jsonschema = "3.2.0"
+cloudpickle = "1.6.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tapipy/actors.py
+++ b/tapipy/actors.py
@@ -1,5 +1,4 @@
 import ast
-import getpass
 import json
 import os
 import socket


### PR DESCRIPTION
1. Added `cloudpickle = "1.6.0"` to pyproject.toml to support functions in tapipy.actors
2. Removed unused `getpass` import in tapipy.actors.