### PR TITLE
Bugfix/raw jwt

### DIFF
--- a/tapipy/tapis.py
+++ b/tapipy/tapis.py
@@ -408,7 +408,7 @@ class Tapis(object):
 
         # pass in a "raw" JWT directly. This is only used if the access_token is not set.
         self.jwt = jwt
-        if not self.access_token and type(self.jwt) == str:
+        if not self.access_token and self.jwt and type(self.jwt) == str:
             tok = TapisResult(**{'access_token': self.jwt})
             self.jwt = self.add_claims_to_token(tok)
             self.access_token = self.jwt


### PR DESCRIPTION
Claims missing from access token when client initialized with "jwt" keyword.

Added claims when initialized with "jwt"